### PR TITLE
Update helk_linux_deb_install.sh

### DIFF
--- a/scripts/helk_linux_deb_install.sh
+++ b/scripts/helk_linux_deb_install.sh
@@ -50,6 +50,13 @@ ERROR=$?
     if [ $ERROR -ne 0 ]; then
         echoerror "Could not install openjdk-8-jre-headless (Error Code: $ERROR)."
     fi
+    
+echo "[HELK-BASH-INSTALLATION-INFO] Installing curl.."
+apt-get install -y curl >> $LOGFILE 2>&1
+ERROR=$?
+    if [ $ERROR -ne 0 ]; then
+        echoerror "Could not install curl (Error Code: $ERROR)."
+    fi    
 
 # Elastic signs all of their packages with their own Elastic PGP signing key.
 echo "[HELK-BASH-INSTALLATION-INFO] Downloading and installing (writing to a file) the public signing key to the host.."


### PR DESCRIPTION
While installing the HELK from local bash script, process did not go further in "Creating Kibana index-patterns, dashboards and visualizations automatically.." step. After some debugging, the problem detected in helk_kibana_setup.sh script which uses "curl". "curl" is not installed by default in 16.04.2 Ubuntu. As a conclusion, installation of "curl" was added to this script.