### PR TITLE
Update kafka-init

### DIFF
--- a/kafka/kafka-init
+++ b/kafka/kafka-init
@@ -34,7 +34,7 @@ fi
 
 KAFKA_HOME=/opt/helk/kafka/kafka_2.11-1.0.0
 KAFKA_USER=root
-KAFKA_USER=root
+KAFKA_GROUP=root
 KAFKA_NICE=18
 SERVICE_NAME="kafka"
 SERVICE_DESCRIPTION="kafka"


### PR DESCRIPTION
The KAFKA_USER variable was listed twice. It seemed to cause an issue with kafka when first starting up. After updating the issue went away.