### PR TITLE
Changed container references in Docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.2'
 services:
 
   helk-elk:
-    image: cyb3rward0g/helk-elk:6.2.2
+    build: ./helk-elk
     container_name: helk-elk
     volumes:
       - esdata:/var/lib/elasticsearch
@@ -25,7 +25,7 @@ services:
         aliases:
           - helk_elk.hunt.local
   helk-kafka:
-    image: cyb3rward0g/helk-kafka:1.0.0
+    build: ./helk-kafka
     container_name: helk-kafka
     env_file: ./helk.env
     ports:
@@ -42,7 +42,7 @@ services:
         aliases:
           - helk_kafka.hunt.local
   helk-analytics:
-    image: cyb3rward0g/helk-analytics:0.0.1
+    build: ./helk-analytics/
     container_name: helk-analytics
     ports:
       - "8880:8880"


### PR DESCRIPTION
Docker compose file referred to images, now points to source code of this repository, such that `docker-compose build` works.