### PR TITLE
Added snap as fallback installation method for Docker

### DIFF
--- a/helk_install.sh
+++ b/helk_install.sh
@@ -28,7 +28,7 @@ check_min_requirements(){
         AVAILABLE_MEMORY=$(free -hm | awk 'NR==2{printf "%.f\t\t", $4 }')
         ES_MEMORY=$(free -hm | awk 'NR==2{printf "%.f", $4/2 }')
         AVAILABLE_DISK=$(df -h | awk '$NF=="/"{printf "%.f\t\t", $4}')
-        
+
         if [ "${AVAILABLE_MEMORY}" -ge "10" ] && [ "${AVAILABLE_DISK}" -ge "30" ]; then
             echo "[HELK-INSTALLATION-INFO] Available Memory: $AVAILABLE_MEMORY"
             echo "[HELK-INSTALLATION-INFO] Available Disk: $AVAILABLE_DISK"
@@ -105,11 +105,18 @@ install_docker(){
     ERROR=$?
     if [ $ERROR -ne 0 ]; then
         echoerror "Could not install docker via convenience script (Error Code: $ERROR)."
-        echo "[HELK-INSTALLATION-INFO] Trying to docker install via snap.."
-        snap install docker >> $LOGFILE 2>&1
-        ERROR=$?
-        if [ $ERROR -ne 0 ]; then
-            echoerror "Could not install docker via snap (Error Code: $ERROR)."
+        if [ -x "$(command -v snap)" ]; then
+            SNAP_VERSION=$(snap version | grep -w 'snap' | awk '{print $2}')
+            echo "[HELK-INSTALLATION-INFO] Snap v$SNAP_VERSION is available. Trying to install docker via snap.."
+            snap install docker >> $LOGFILE 2>&1
+            ERROR=$?
+            if [ $ERROR -ne 0 ]; then
+                echoerror "Could not install docker via snap (Error Code: $ERROR)."
+                exit 1
+            fi
+            echo "[HELK-INSTALLATION-INFO] Docker successfully installed via snap."            
+        else
+            echo "[HELK-INSTALLATION-INFO] Docker could not be installed. Check /var/log/helk-install.log for details."
             exit 1
         fi
     fi

--- a/helk_install.sh
+++ b/helk_install.sh
@@ -105,7 +105,13 @@ install_docker(){
     ERROR=$?
     if [ $ERROR -ne 0 ]; then
         echoerror "Could not install docker via convenience script (Error Code: $ERROR)."
-        exit 1
+        echo "[HELK-INSTALLATION-INFO] Trying to docker install via snap.."
+        snap install docker >> $LOGFILE 2>&1
+        ERROR=$?
+        if [ $ERROR -ne 0 ]; then
+            echoerror "Could not install docker via snap (Error Code: $ERROR)."
+            exit 1
+        fi
     fi
 }
 


### PR DESCRIPTION
**What is this PR for?**
While testing out HELK on Ubuntu Bionic, docker installation often failed with error 100 and message  "Package 'docker-ce' has no installation candidate". So I thought of adding snap as the fallback installation method.
![error100](https://user-images.githubusercontent.com/3139249/40034299-f7f10c18-5819-11e8-9e33-cc165037366e.PNG)


**What type of PR is it?**
Bug Fix

**How should this be tested?**
Run helk_install.sh normally, installation via snap would occur if the convenience script fails. This can be seen in the last 2 lines in the screenshot above & below (it succeeds to install via snap in the last line)
![snap_success](https://user-images.githubusercontent.com/3139249/40034386-4b5149ea-581a-11e8-94e0-e49051518408.PNG)

**Questions:**
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? No
