### PR TITLE
convert process/logon IDs from hex only if they start with 0x

### DIFF
--- a/docker/helk-logstash/pipeline/1543-winevent-conversions-process-cli-filter.conf
+++ b/docker/helk-logstash/pipeline/1543-winevent-conversions-process-cli-filter.conf
@@ -7,7 +7,7 @@ filter {
 
     if [event_id] {
 
-        if [user_logon_id] {
+        if [user_logon_id] =~ /^0x/ {
           mutate { add_field => { "z_logstash_pipeline" => "1543_1" } }
           mutate { gsub => [ "user_logon_id", "0x", "" ]}
           ruby {
@@ -15,7 +15,7 @@ filter {
             tag_on_exception =>  "_rubyexception_1543_1"
           }
         }
-        if [process_id] {
+        if [process_id] =~ /^0x/ {
           mutate { add_field => { "z_logstash_pipeline" => "1543_2" } }
           mutate { gsub => [ "process_id", "0x", "" ]}
           ruby {
@@ -23,7 +23,7 @@ filter {
             tag_on_exception =>  "_rubyexception_1543_2"
           }
         }
-        if [process_parent_id] {
+        if [process_parent_id] =~ /^0x/ {
           mutate { add_field => { "z_logstash_pipeline" => "1543_3" } }
           mutate { gsub => [ "process_parent_id", "0x", "" ]}
           ruby {
@@ -31,7 +31,7 @@ filter {
             tag_on_exception =>  "_rubyexception_1543_3"
           }
         }
-        if [target_process_id] {
+        if [target_process_id] =~ /^0x/ {
           mutate { add_field => { "z_logstash_pipeline" => "1543_4" } }
           mutate { gsub => [ "target_process_id", "0x", "" ]}
           ruby {


### PR DESCRIPTION
**What is this PR for?**
This PR is to fix an issue where _all_ process IDs are being converted from hex format to decimal. Many Windows logs use the hex format, but others (Sysmon, for example) do not and those logs are being converted erroneously. 

**What type of PR is it?**
[Bug Fix] 

**How should this be tested?**
Specific steps, configs and images if available
Send log event from Sysmon with a process ID and compare the process_id field with the Process ID in the z_original_message field.
Send a Windows 4688 event and compare that the process_id was converted correctly from hex (this is the current behavior) to make sure it did not break.

**Questions:**
* Do the licenses files need update? No
* Are there breaking changes for older versions? No
* Does this needs documentation? No
