### PR TITLE
Downloads docker installer script over HTTPS

### DIFF
--- a/docker/helk_install.sh
+++ b/docker/helk_install.sh
@@ -158,7 +158,7 @@ install_htpasswd(){
 # ****** Installing docker via convenience script ***********
 install_docker(){
     echo "[HELK-INSTALLATION-INFO] Installing docker via convenience script.."
-    curl -fsSL get.docker.com -o get-docker.sh >> $LOGFILE 2>&1
+    curl -fsSL https://get.docker.com -o get-docker.sh >> $LOGFILE 2>&1
     chmod +x get-docker.sh >> $LOGFILE 2>&1
     ./get-docker.sh >> $LOGFILE 2>&1
     ERROR=$?


### PR DESCRIPTION
**What is this PR for?**
Small change to download docker over HTTPS instead of HTTP

**What type of PR is it?**
[Bug Fix]

**How should this be tested?**
Try and run the install script and verify it still works.

**Questions:**
* Do the licenses files need update? No
* Are there breaking changes for older versions? No
* Does this needs documentation? No
