### PR TITLE
Persisting configuration between scripts

### DIFF
--- a/docker/helk_install.sh
+++ b/docker/helk_install.sh
@@ -443,10 +443,10 @@ persist_conf(){
         sed -i -e "s/$SC/$SUBSCRIPTION_CHOICE/g" $CONF_FILE >> $LOGFILE 2>&1
     else
         touch $CONF_FILE >> $LOGFILE 2>&1
-        echo "MAX_MAP_COUNT=262144" >> $CONF_FILE >> $LOGFILE 2>&1
-        echo "HOST_IP=$HOST_IP" >> $CONF_FILE >> $LOGFILE 2>&1
-        echo "HELK_BUILD=$HELK_BUILD" >> $CONF_FILE >> $LOGFILE 2>&1
-        echo "SUBSCRIPTION_CHOICE=$SUBSCRIPTION_CHOICE" >> $CONF_FILE >> $LOGFILE 2>&1
+        echo "MAX_MAP_COUNT=262144" >> $CONF_FILE
+        echo "HOST_IP=$HOST_IP" >> $CONF_FILE
+        echo "HELK_BUILD=$HELK_BUILD" >> $CONF_FILE
+        echo "SUBSCRIPTION_CHOICE=$SUBSCRIPTION_CHOICE" >> $CONF_FILE
     fi
 }
 

--- a/docker/helk_install.sh
+++ b/docker/helk_install.sh
@@ -429,7 +429,7 @@ prepare_helk(){
 
 persist_conf(){
     if [ ! -d "/usrl/local/helk" ]; then
-        mkdir -p /usr/local/helk
+        mkdir -p /usr/local/helk >> $LOGFILE 2>&1
     fi
 
     if [[ -e $CONF_FILE ]]; then
@@ -437,16 +437,16 @@ persist_conf(){
         HI=$(cat $CONF_FILE | grep HOST_IP | cut -d'=' -f2)
         HB=$(cat $CONF_FILE | grep HELK_BUILD | cut -d'=' -f2)
         SC=$(cat $CONF_FILE | grep SUBSCRIPTION_CHOICE | cut -d'=' -f2)
-        sed -i -e "s/$MMC/262144/g" $CONF_FILE
-        sed -i -e "s/$HI/$HOST_IP/g" $CONF_FILE
-        sed -i -e "s/$HB/$HELK_BUILD/g" $CONF_FILE
-        sed -i -e "s/$SC/$SUBSCRIPTION_CHOICE/g" $CONF_FILE
+        sed -i -e "s/$MMC/262144/g" $CONF_FILE >> $LOGFILE 2>&1
+        sed -i -e "s/$HI/$HOST_IP/g" $CONF_FILE >> $LOGFILE 2>&1
+        sed -i -e "s/$HB/$HELK_BUILD/g" $CONF_FILE >> $LOGFILE 2>&1
+        sed -i -e "s/$SC/$SUBSCRIPTION_CHOICE/g" $CONF_FILE >> $LOGFILE 2>&1
     else
-        touch $CONF_FILE    
-        echo "MAX_MAP_COUNT=262144" >> $CONF_FILE
-        echo "HOST_IP=$HOST_IP" >> $CONF_FILE
-        echo "HELK_BUILD=$HELK_BUILD" >> $CONF_FILE
-        echo "SUBSCRIPTION_CHOICE=$SUBSCRIPTION_CHOICE" >> $CONF_FILE  
+        touch $CONF_FILE >> $LOGFILE 2>&1
+        echo "MAX_MAP_COUNT=262144" >> $CONF_FILE >> $LOGFILE 2>&1
+        echo "HOST_IP=$HOST_IP" >> $CONF_FILE >> $LOGFILE 2>&1
+        echo "HELK_BUILD=$HELK_BUILD" >> $CONF_FILE >> $LOGFILE 2>&1
+        echo "SUBSCRIPTION_CHOICE=$SUBSCRIPTION_CHOICE" >> $CONF_FILE >> $LOGFILE 2>&1
     fi
 }
 

--- a/docker/helk_update.sh
+++ b/docker/helk_update.sh
@@ -221,6 +221,9 @@ update_helk() {
     check_min_requirements
 
     echo -e "${CYAN}[HELK-UPDATE-INFO]${STD} Rebuilding HELK via docker-compose"
+
+    export ADVERTISED_LISTENER=$(cat $CONF_FILE | grep HOST_IP | cut -d'=' -f2)
+
     docker-compose -f $COMPOSE_CONFIG up --build -d -V --force-recreate --always-recreate-deps >> $LOGFILE 2>&1
     ERROR=$?
     if [ $ERROR -ne 0 ]; then
@@ -240,6 +243,7 @@ update_helk() {
 }
 
 LOGFILE="/var/log/helk-update.log"
+CONF_FILE="/usr/local/helk/helk.conf"
 REBUILD_NEEDED=0
 GIT_REPO_CLEAN=1
 


### PR DESCRIPTION
**What is this PR for?**
This PR adds a feature that persists helk install config to a local file, so that data can be persisted between different scripts (like the install and update scripts). This has been thought of to fix Kafka issues as mentioned by @ker0z in issue #136 and may prove useful for future scripts/features.

**What type of PR is it?**
Bug Fix

**How should this be tested?**

Change directory to ```$HELK_DIR/docker``` and run ```sudo ./helk_install.sh```. Configuration variables should be written to ```/usr/local/helk/helk.conf```

**Questions:**
* Do the licenses files need update? No
* Are there breaking changes for older versions? No
* Does this needs documentation? No
