### PR TITLE
Update helk_install.sh

### DIFF
--- a/docker/helk_install.sh
+++ b/docker/helk_install.sh
@@ -23,6 +23,10 @@ INSTALL_MINIMUM_MEMORY_NOTEBOOK=8000
 ## In GBs
 INSTALL_MINIMUM_DISK=25
 
+export DOCKER_CLIENT_TIMEOUT=300
+export COMPOSE_HTTP_TIMEOUT=300
+
+
 # *********** Check if user is root ***************
 if [[ $EUID -ne 0 ]]; then
    echo "$HELK_INFO_TAG YOU MUST BE ROOT TO RUN THIS SCRIPT!!!"


### PR DESCRIPTION
Also found a bug in this script but can't sort out what the hell this awk line is doing ?

AVAILABLE_DOCKER_DISK=$(df -m $(docker info --format '{{.DockerRootDir}}') | awk '$1 ~ /\//{printf "%.f", $4 / 1024}')


it needs to pull 999999 when overlay is mounted but still work with /dev/sda etc  

overlay 4444444 4444444 999999 9%  /

**What is this PR for?**
fix for slower systems

**What type of PR is it?**
[Bug Fix]  


**How should this be tested?**
Specific steps, configs and images if available


**Questions:**
* Do the licenses files need update? No
* Are there breaking changes for older versions? No
* Does this needs documentation? No
