### PR TITLE
Temporary elastalert hotfix

### DIFF
--- a/docker/helk-kibana-analysis-alert-basic.yml
+++ b/docker/helk-kibana-analysis-alert-basic.yml
@@ -141,7 +141,7 @@ services:
     networks:
       helk:
   helk-elastalert:
-    image: cyb3rward0g/helk-elastalert:0.2.4
+    build: helk-elastalert/
     container_name: helk-elastalert
     restart: always
     depends_on:

--- a/docker/helk-kibana-analysis-alert-trial.yml
+++ b/docker/helk-kibana-analysis-alert-trial.yml
@@ -142,7 +142,7 @@ services:
     networks:
       helk:
   helk-elastalert:
-    image: cyb3rward0g/helk-elastalert:0.2.4
+    build: helk-elastalert/
     container_name: helk-elastalert
     restart: always
     depends_on:

--- a/docker/helk-kibana-notebook-analysis-alert-basic.yml
+++ b/docker/helk-kibana-notebook-analysis-alert-basic.yml
@@ -180,7 +180,7 @@ services:
     networks:
       helk:
   helk-elastalert:
-    image: cyb3rward0g/helk-elastalert:0.2.4
+    build: helk-elastalert/
     container_name: helk-elastalert
     restart: always
     depends_on:

--- a/docker/helk-kibana-notebook-analysis-alert-trial.yml
+++ b/docker/helk-kibana-notebook-analysis-alert-trial.yml
@@ -182,7 +182,7 @@ services:
     networks:
       helk:
   helk-elastalert:
-    image: cyb3rward0g/helk-elastalert:0.2.4
+    build: helk-elastalert/
     container_name: helk-elastalert
     restart: always
     depends_on:


### PR DESCRIPTION
use latest elastalert repo, that fixes many of the compatibility issues that elastalert previously had with elasticsearch 7.x