### PR TITLE
Update helk_install.sh

### DIFF
--- a/docker/helk_install.sh
+++ b/docker/helk_install.sh
@@ -210,6 +210,15 @@ install_docker_compose(){
     COMPOSE_VERSION=$(curl -s https://api.github.com/repos/docker/compose/releases/latest | grep 'tag_name' | cut -d\" -f4)
     curl -L https://github.com/docker/compose/releases/download/$COMPOSE_VERSION/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose >> $LOGFILE 2>&1
     chmod +x /usr/local/bin/docker-compose >> $LOGFILE 2>&1
+    OSNAME=$(cat /etc/os-release | grep "PRETTY_NAME" | cut -d '=' -f 2)
+    if [[ $OSNAME == *"CentOS"* ]]; then
+        if ! [[ $PATH == *"/usr/local/bin"* ]]; then # small check not to have it 2 times
+            export PATH=$PATH:/usr/local/bin
+        else
+            echo "[INFO] /usr/local/bin is already in PATH environment variable !"
+        fi
+        docker-compose version
+    fi
     ERROR=$?
     if [ $ERROR -ne 0 ]; then
         echoerror "Could not install docker-compose (Error Code: $ERROR)."

--- a/docker/helk_remove_containers.sh
+++ b/docker/helk_remove_containers.sh
@@ -16,7 +16,7 @@ fi
 export PATH=$PATH:/usr/local/bin
 
 # *********** Get configuration ***************
-$CONFIG=helk-kibana-analysis-basic.yml
+read -ep "Which config file did you install ? (please provide file name with extension) " CONFIG
 
 # *********** Set Log File ***************
 LOGFILE="/var/log/helk-install.log"

--- a/docker/helk_remove_containers.sh
+++ b/docker/helk_remove_containers.sh
@@ -12,6 +12,12 @@ if [[ $EUID -ne 0 ]]; then
    exit 1
 fi
 
+# *********** Add docker-compose path ***************
+export PATH=$PATH:/usr/local/bin
+
+# *********** Get configuration ***************
+$CONFIG=helk-kibana-analysis-basic.yml
+
 # *********** Set Log File ***************
 LOGFILE="/var/log/helk-install.log"
 echoerror() {
@@ -19,7 +25,7 @@ echoerror() {
 }
 
 echo "[HELK-REMOVE-CONTAINERS] Stopping all running containers.."
-docker stop $(docker ps -a | awk '{ print $1,$2 }' | grep helk | awk '{print $1 }') >> $LOGFILE 2>&1
+docker-compose -f $CONFIG stop
 ERROR=$?
 if [ $ERROR -ne 0 ]; then
     echoerror "Could not stop running containers.."
@@ -27,6 +33,7 @@ if [ $ERROR -ne 0 ]; then
 fi
 
 echo "[HELK-REMOVE-CONTAINERS] Removing all containers.."
+docker-compose -f $CONFIG rm
 docker rm $(docker ps -a | awk '{ print $1,$2 }' | grep helk | awk '{print $1 }') >> $LOGFILE 2>&1
 ERROR=$?
 if [ $ERROR -ne 0 ]; then

--- a/docker/helk_remove_containers.sh
+++ b/docker/helk_remove_containers.sh
@@ -25,7 +25,7 @@ echoerror() {
 }
 
 echo "[HELK-REMOVE-CONTAINERS] Stopping all running containers.."
-docker-compose -f $CONFIG stop
+docker-compose -f $CONFIG stop >> $LOGFILE 2>&1
 ERROR=$?
 if [ $ERROR -ne 0 ]; then
     echoerror "Could not stop running containers.."
@@ -33,8 +33,7 @@ if [ $ERROR -ne 0 ]; then
 fi
 
 echo "[HELK-REMOVE-CONTAINERS] Removing all containers.."
-docker-compose -f $CONFIG rm
-docker rm $(docker ps -a | awk '{ print $1,$2 }' | grep helk | awk '{print $1 }') >> $LOGFILE 2>&1
+docker-compose -f $CONFIG rm >> $LOGFILE 2>&1
 ERROR=$?
 if [ $ERROR -ne 0 ]; then
     echoerror "Could not remove containers.."


### PR DESCRIPTION
**What is this PR for?**
Added some commands for centos users. This solves an issue where HELK didn't install `docker-compose` and made installation impossible.

When you install `docker-compose` via this script with a user that is not root, the path to the `docker-compose` binary, which is `/usr/local/bin` is not added to the env variable PATH. To solve this issue I added a little check to the installation script that will add the path to the environment variable PATH if it doesn't contain it. If PATH does contain `/usr/local/bin`, we skip this part.

**What type of PR is it?**
[Bug Fix]

**How should this be tested?**
Specific steps, configs, and images if available
It should be tested by trying to install HELK on a Centos7 server *WITHOUT* docker nor docker-compose installed.

**Questions:**
* Do the licenses files need an update? No
* Are there breaking changes for older versions? No
* Does this needs documentation? No