### PR TITLE
increase elastalert efficiency

### DIFF
--- a/docker/helk-elastalert/config.yaml
+++ b/docker/helk-elastalert/config.yaml
@@ -10,9 +10,9 @@
 
 rules_folder: rules
 run_every:
-    seconds: 30
+    seconds: 60
 buffer_time:
-    seconds: 45
+    seconds: 900
 es_host: helk-elasticsearch
 es_port: 9200
 alert_time_limit:


### PR DESCRIPTION
buffer time needs to be increased to take into many considerations such as log delays or elastalert getting push back 
additionally run every minute to decrease back pressure