### PR TITLE
Logstash password update after rebuilding the container

### DIFF
--- a/docker/helk-logstash/scripts/logstash-entrypoint.sh
+++ b/docker/helk-logstash/scripts/logstash-entrypoint.sh
@@ -58,7 +58,7 @@ if [[ -n "$ELASTIC_PASSWORD" ]]; then
   for config in /usr/share/logstash/pipeline/*-output.conf
   do
       echo "$HELK_LOGSTASH_INFO_TAG Updating pipeline config $config..."
-      sed -i "s/#password \=>.*$/password \=> \'${ELASTIC_PASSWORD}\'/g" "${config}"
+      sed -i "s/\(#\)\{0,1\}password \=>.*$/password \=> \'${ELASTIC_PASSWORD}\'/g" "${config}"
   done
 fi
 


### PR DESCRIPTION
**What is this PR for?**
Recently I got a request to change the Elasticsearch password in the existing HELK stack. I found out 
 that the ES password has relationship with few services, and they all could be updated by rebuilding new container. 

However Logstash is not the case. Logstash docker updating new password by using `sed` command targeting to pipeline configurations. However the command only support the case that password are commented (the default pipelines from the built-in Logstash docker), which won't update the password after the first run. This PR simply cover that case.

```bash
sed -i "s/#password \=>.*$/password \=> \'${ELASTIC_PASSWORD}\'/g" "${config}"
```

**What type of PR is it?**
Bug Fix

**How should this be tested?**
Reproduce steps:
1. Create .env file in docker folder, set ELASTIC_PASSWORD inside the file
2. Run the stack
3. Change the ELASTIC_PASSWORD in .env file, rebuild all the related services: Elasticsearch, Logstash, Kibana, ElastAlert
4. Push some pre-recorded data to Kafka or Logstash and there are errors like this in Logstash docker

```
helk-logstash         | [2020-02-14T08:26:27,950][WARN ][logstash.outputs.elasticsearch][main] Attempted to resurrect conne
ction to dead ES instance, but got an error. {:url=>"http://elastic:xxxxxx@helk-elasticsearch:9200/", :error_type=>LogStash
::Outputs::ElasticSearch::HttpClient::Pool::BadResponseCodeError, :error=>"Got response code '401' contacting Elasticsearch
 at URL 'http://helk-elasticsearch:9200/'"}                                                                                
```

