### PR TITLE
Added port forwarding (9200) to ES container

### DIFF
--- a/docker/helk-kibana-analysis-alert-basic.yml
+++ b/docker/helk-kibana-analysis-alert-basic.yml
@@ -17,6 +17,8 @@ services:
       - ./helk-elasticsearch/scripts:/usr/share/elasticsearch/scripts
       - ./helk-elasticsearch/config/jvm.options:/usr/share/elasticsearch/config/jvm.options
     entrypoint: /usr/share/elasticsearch/scripts/elasticsearch-entrypoint.sh
+    ports:
+      - "9200:9200"
     environment:
       - cluster.name=helk-cluster
       - node.name=helk-1

--- a/docker/helk-kibana-analysis-alert-trial.yml
+++ b/docker/helk-kibana-analysis-alert-trial.yml
@@ -17,6 +17,8 @@ services:
       - ./helk-elasticsearch/scripts:/usr/share/elasticsearch/scripts
       - ./helk-elasticsearch/config/jvm.options:/usr/share/elasticsearch/config/jvm.options
     entrypoint: /usr/share/elasticsearch/scripts/elasticsearch-entrypoint.sh
+    ports:
+      - "9200:9200"
     environment:
       - cluster.name=helk-cluster
       - node.name=helk-1

--- a/docker/helk-kibana-analysis-basic.yml
+++ b/docker/helk-kibana-analysis-basic.yml
@@ -17,6 +17,8 @@ services:
       - ./helk-elasticsearch/scripts:/usr/share/elasticsearch/scripts
       - ./helk-elasticsearch/config/jvm.options:/usr/share/elasticsearch/config/jvm.options
     entrypoint: /usr/share/elasticsearch/scripts/elasticsearch-entrypoint.sh
+    ports:
+      - "9200:9200"    
     environment:
       - cluster.name=helk-cluster
       - node.name=helk-1

--- a/docker/helk-kibana-analysis-trial.yml
+++ b/docker/helk-kibana-analysis-trial.yml
@@ -17,6 +17,8 @@ services:
       - ./helk-elasticsearch/scripts:/usr/share/elasticsearch/scripts
       - ./helk-elasticsearch/config/jvm.options:/usr/share/elasticsearch/config/jvm.options
     entrypoint: /usr/share/elasticsearch/scripts/elasticsearch-entrypoint.sh
+    ports:
+      - "9200:9200"
     environment:
       - cluster.name=helk-cluster
       - node.name=helk-1

--- a/docker/helk-kibana-notebook-analysis-alert-basic.yml
+++ b/docker/helk-kibana-notebook-analysis-alert-basic.yml
@@ -17,6 +17,8 @@ services:
       - ./helk-elasticsearch/scripts:/usr/share/elasticsearch/scripts
       - ./helk-elasticsearch/config/jvm.options:/usr/share/elasticsearch/config/jvm.options
     entrypoint: /usr/share/elasticsearch/scripts/elasticsearch-entrypoint.sh
+    ports:
+      - "9200:9200"
     environment:
       - cluster.name=helk-cluster
       - node.name=helk-1

--- a/docker/helk-kibana-notebook-analysis-alert-trial.yml
+++ b/docker/helk-kibana-notebook-analysis-alert-trial.yml
@@ -17,6 +17,8 @@ services:
       - ./helk-elasticsearch/scripts:/usr/share/elasticsearch/scripts
       - ./helk-elasticsearch/config/jvm.options:/usr/share/elasticsearch/config/jvm.options
     entrypoint: /usr/share/elasticsearch/scripts/elasticsearch-entrypoint.sh
+    ports:
+      - "9200:9200"
     environment:
       - cluster.name=helk-cluster
       - node.name=helk-1

--- a/docker/helk-kibana-notebook-analysis-basic.yml
+++ b/docker/helk-kibana-notebook-analysis-basic.yml
@@ -17,6 +17,8 @@ services:
       - ./helk-elasticsearch/scripts:/usr/share/elasticsearch/scripts
       - ./helk-elasticsearch/config/jvm.options:/usr/share/elasticsearch/config/jvm.options
     entrypoint: /usr/share/elasticsearch/scripts/elasticsearch-entrypoint.sh
+    ports:
+      - "9200:9200"
     environment:
       - cluster.name=helk-cluster
       - node.name=helk-1

--- a/docker/helk-kibana-notebook-analysis-trial.yml
+++ b/docker/helk-kibana-notebook-analysis-trial.yml
@@ -17,6 +17,8 @@ services:
       - ./helk-elasticsearch/scripts:/usr/share/elasticsearch/scripts
       - ./helk-elasticsearch/config/jvm.options:/usr/share/elasticsearch/config/jvm.options
     entrypoint: /usr/share/elasticsearch/scripts/elasticsearch-entrypoint.sh
+    ports:
+      - "9200:9200"
     environment:
       - cluster.name=helk-cluster
       - node.name=helk-1


### PR DESCRIPTION
**What is this PR for?**
Port forwarding port 9200 for ElasticSearch container, so other systems can use the data collected by HELK.
Issue: https://github.com/Cyb3rWard0g/HELK/issues/443

**What type of PR is it?**
[Feature Request]

**How should this be tested?**


**Questions:**
* Do the licenses files need update? No
* Are there breaking changes for older versions? No
* Does this needs documentation? No
