### PR TITLE
Added two native Elastalert rules to the repo

### DIFF
--- a/docker/helk-elastalert/rules/helk_sysmon_lsass_memdump.yml
+++ b/docker/helk-elastalert/rules/helk_sysmon_lsass_memdump.yml
@@ -1,5 +1,14 @@
-        TargetImage: 'C:\windows\system32\lsass.exe'
-        GrantedAccess: '0x1fffff'
-        CallTrace:
-         - '*dbghelp.dll*'
-         - '*dbgcore.dll*'
+
+alert:
+- debug
+description: Detects process LSASS memory dump using procdump or taskmgr based on
+  the CallTrace pointing to dbghelp.dll or dbgcore.dll for win10
+filter:
+- query:
+    query_string:
+      query: (event_id:"10" AND target_process_path.keyword:(*\\lsass.exe) AND process_granted_access_orig:0x1fffff AND process_call_trace.keyword:(*dbghelp.dll* OR *dbgcore.dll*))
+name: LSASS-Memory-Dump_0
+priority: 2
+realert:
+  minutes: 0
+type: any

--- a/docker/helk-elastalert/rules/helk_sysmon_lsass_memdump.yml
+++ b/docker/helk-elastalert/rules/helk_sysmon_lsass_memdump.yml
@@ -1,4 +1,3 @@
-
 alert:
 - debug
 description: Detects process LSASS memory dump using procdump or taskmgr based on
@@ -7,6 +6,7 @@ filter:
 - query:
     query_string:
       query: (event_id:"10" AND target_process_path.keyword:(*\\lsass.exe) AND process_granted_access_orig:0x1fffff AND process_call_trace.keyword:(*dbghelp.dll* OR *dbgcore.dll*))
+index: logs-endpoint-winevent-sysmon-*
 name: LSASS-Memory-Dump_0
 priority: 2
 realert:

--- a/docker/helk-elastalert/rules/helk_sysmon_lsass_memdump.yml
+++ b/docker/helk-elastalert/rules/helk_sysmon_lsass_memdump.yml
@@ -1,0 +1,5 @@
+        TargetImage: 'C:\windows\system32\lsass.exe'
+        GrantedAccess: '0x1fffff'
+        CallTrace:
+         - '*dbghelp.dll*'
+         - '*dbgcore.dll*'

--- a/docker/helk-elastalert/rules/helk_win_susp_security_eventlog_cleared.yml
+++ b/docker/helk-elastalert/rules/helk_win_susp_security_eventlog_cleared.yml
@@ -4,7 +4,7 @@ description: Some threat groups tend to delete the local 'Security' Eventlog.
 filter:
 - query:
     query_string:
-      query: (event_id:("517") OR event_id:("1102"))
+      query: (event_id:("517" OR "1102"))
 index: logs-endpoint-winevent-security-*
 name: Security-Eventlog-Cleared_0
 priority: 2

--- a/docker/helk-elastalert/rules/helk_win_susp_security_eventlog_cleared.yml
+++ b/docker/helk-elastalert/rules/helk_win_susp_security_eventlog_cleared.yml
@@ -1,0 +1,13 @@
+alert:
+- debug
+description: Some threat groups tend to delete the local 'Security' Eventlog.
+filter:
+- query:
+    query_string:
+      query: (event_id:("517") OR event_id:("1102"))
+index: logs-endpoint-winevent-security-*
+name: Security-Eventlog-Cleared_0
+priority: 2
+realert:
+  minutes: 0
+type: any


### PR DESCRIPTION
**What is this PR for?**
Additional of two native Elastalert rules to the repo. (sigmac conversion not currently working correctly so I've created these for now)

**What type of PR is it?**
HELK Elastalert rules

**How should this be tested?**

Tested by replaying events. 

- [DE_1102_security_log_cleared.evtx](https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES/blob/master/Defense%20Evasion/DE_1102_security_log_cleared.evtx)

- [sysmon_10_11_lsass_memdump.evtx](https://github.com/sbousseaden/EVTX-ATTACK-SAMPLES/blob/master/Credential%20Access/sysmon_10_11_lsass_memdump.evtx)

**PLEASE NOTE :** to replay events with elastalert, you will need add the following line to the rule being tested before replaying so elastalert is looking at the timestamp of ingestion:

- _timestamp_field: etl_processed_time_


**Questions:**
* Do the licenses files need update? No
* Are there breaking changes for older versions? No
* Does this needs documentation? No
