### PR TITLE
Freeze docker-compose version due to glibc incompatibility in newer docker-compose

### DIFF
--- a/docker/helk_install.sh
+++ b/docker/helk_install.sh
@@ -271,8 +271,8 @@ install_docker() {
 # ****** Installing docker compose from github.com/docker/compose ***********
 install_docker_compose() {
   echo "$HELK_INFO_TAG Installing docker-compose.."
-  COMPOSE_VERSION=$(curl -s https://api.github.com/repos/docker/compose/releases/latest | grep 'tag_name' | cut -d\" -f4)
-  curl -L https://github.com/docker/compose/releases/download/"$COMPOSE_VERSION"/docker-compose-"$(uname -s)"-"$(uname -m)" -o /usr/local/bin/docker-compose >>$LOGFILE 2>&1
+  # Freeze docker-compose at version 1.27.4 due to glibc version requirements in 1.28 not matching recommended distros for HELK
+  curl -L https://github.com/docker/compose/releases/download/1.27.4/docker-compose-"$(uname -s)"-"$(uname -m)" -o /usr/local/bin/docker-compose >>$LOGFILE 2>&1
   chmod +x /usr/local/bin/docker-compose >>$LOGFILE 2>&1
   if [ "$LSB_DIST" == "centos" ]; then
     # Link docker-compose so can be used with sudo


### PR DESCRIPTION
**What is this PR for?**
Version 1.28 of docker-compose uses a newer version of glibc than the supported CentOS and Ubuntu versions. This PR forces version 1.27.4 of docker-compose to keep compatibility with the supported distros. Fixes #538 

**What type of PR is it?**
[Bug Fix]

**How should this be tested?**
Run helk_install.sh

**Questions:**
* Do the licenses files need update? No
* Are there breaking changes for older versions? No
* Does this needs documentation? No
