### PR TITLE
Update 1010-winevent-winlogbeats-filter.conf

### DIFF
--- a/docker/helk-logstash/pipeline/1010-winevent-winlogbeats-filter.conf
+++ b/docker/helk-logstash/pipeline/1010-winevent-winlogbeats-filter.conf
@@ -43,7 +43,7 @@ filter {
   }
   #TODO: if ever needing to distinguish minor versions between 7 or 8 (ie: if major change from say 7.7.2 and 7.8.1) then use `agent.version` for the logic to accomplish what is needed
   # Winlogbeat >= 7.x
-  else if [agent][type] == "winlogbeat" {
+  else if [agent][type] == "winlogbeat"  or [winlog] {
     ruby {
       code => '
         # event_data nested field


### PR DESCRIPTION
elastic seems to be deprecating agent and beat object fields
