### PR TITLE
Install Script Typo: "serivce" -> "service"

### DIFF
--- a/docker/helk_setup_firewall.sh
+++ b/docker/helk_setup_firewall.sh
@@ -32,7 +32,7 @@ echo "$ZONES" | tee -a $LOGFILE
 
 FIRST="$(echo $ZONES | cut -d ' ' -f 1)"
 while true; do
-   read -e -p "$TAG Please enter the zone you want to add the serivce to: " -i "$FIRST" CHOICE
+   read -e -p "$TAG Please enter the zone you want to add the service to: " -i "$FIRST" CHOICE
    if [[ $ZONES =~ (^| )$CHOICE($| ) ]]; then
       break
    else


### PR DESCRIPTION
**What is this PR for?**
Simple typo I noticed during installation - "serivce" to "service"

**What type of PR is it?**
Bug fix/Typo fix

**How should this be tested?**
No testing required.

**Questions:**
* Do the licenses files need update? No
* Are there breaking changes for older versions? No
* Does this needs documentation? No
